### PR TITLE
Added "slurp_select" alt option

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,4 +1,6 @@
 [
+    { "keys": ["ctrl+f"], "command": "find_selected_next", "args": { "alt": "slurp_search" } },
+    { "keys": ["ctrl+shift+f"], "command": "find_selected_previous", "args": { "alt": "slurp_search" } },
     { "keys": ["f3"], "command": "find_selected_next", "args": { "alt": "last_search" } },
     { "keys": ["shift+f3"], "command": "find_selected_previous", "args": { "alt": "last_search" } },
     { "keys": ["ctrl+f3"], "command": "find_selected_next", "args": { "alt": "clipboard" } },

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,4 +1,6 @@
 [
+    { "keys": ["super+f"], "command": "find_selected_next", "args": { "alt": "slurp_search" } },
+    { "keys": ["super+shift+f"], "command": "find_selected_previous", "args": { "alt": "slurp_search" } },
     { "keys": ["f3"], "command": "find_selected_next", "args": { "alt": "last_search" } },
     { "keys": ["shift+f3"], "command": "find_selected_previous", "args": { "alt": "last_search" } },
     { "keys": ["super+f3"], "command": "find_selected_next", "args": { "alt": "clipboard" } },

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,4 +1,6 @@
 [
+    { "keys": ["ctrl+f"], "command": "find_selected_next", "args": { "alt": "slurp_search" } },
+    { "keys": ["ctrl+shift+f"], "command": "find_selected_previous", "args": { "alt": "slurp_search" } },
     { "keys": ["f3"], "command": "find_selected_next", "args": { "alt": "last_search" } },
     { "keys": ["shift+f3"], "command": "find_selected_previous", "args": { "alt": "last_search" } },
     { "keys": ["ctrl+f3"], "command": "find_selected_next", "args": { "alt": "clipboard" } },

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -5,6 +5,8 @@
         "id": "find",
         "children":
         [
+            { "command": "find_selected_next", "args": {"alt": "slurp_search"}, "caption": "Find selected next (slurp search)…" },
+            { "command": "find_selected_previous", "args": {"alt": "slurp_search"}, "caption": "Find selected previous (slurp search)…" },
             { "command": "find_selected_next", "args": {"alt": "last_search"}, "caption": "Find selected next (last search)…" },
             { "command": "find_selected_previous", "args": {"alt": "last_search"}, "caption": "Find selected previous (last search)…" },
             { "command": "find_selected_next", "args": {"alt": "clipboard"}, "caption": "Find selected next (clipboard)…" },

--- a/README.md
+++ b/README.md
@@ -5,12 +5,13 @@ quickly searching for text within a page.
 
 ## Details ##
 
-Two additional search methods are available:
+Three additional search methods are available:
 
 **find\_selected\_next** - If some text is selected then it is searched for and
 the cursor highlights the next occurrence of the text. If no text is selected then
 depending on the passed argument we either search for the last *Find* search term
-("last_search") or the clipboard ("clipboard").
+("last_search") or the clipboard ("clipboard"). Using ("slurp_search") will cause
+ highlighted text to be added to the Find buffer.
 
 **find\_selected\_previous** - As above but we search backwards
 

--- a/findselected.py
+++ b/findselected.py
@@ -24,6 +24,9 @@ If selection empty then look for the last Find command search term or the clipbo
 
         # If start and end cursor points are different then we have some text selected
         if selected.a != selected.b:
+            # We DO want to call "find_under" and populate the find buffer
+            if alt == "slurp_search":
+                return view.window().run_command("find_under")
             # We don't call "find_under" here as it populates the find panel and
             # so we would lose its value in case we wanted to use it later
             # Get the text of the selection
@@ -34,7 +37,7 @@ If selection empty then look for the last Find command search term or the clipbo
                 selectedPos = selected.b
             else:
                 selectedPos = selected.a
-        elif alt == "last_search":
+        elif alt == "last_search" or alt == "slurp_search":
             # Run the built in find_next command from the window context
             return view.window().run_command("find_next")
         elif alt == "clipboard":
@@ -83,6 +86,9 @@ If selection empty then look for the last Find command search term or the clipbo
 
         # If start and end cursor points are different then we have some text selected
         if selected.a != selected.b:
+            # We DO want to call "find_under_prev" and populate the find buffer
+            if alt == "slurp_search":
+                return view.window().run_command("find_under_prev")
             # We don't call "find_under_previous" here as it populates the find
             # panel and so we would lose its value in case we wanted to use it later
             # Get the text of the selection
@@ -93,7 +99,7 @@ If selection empty then look for the last Find command search term or the clipbo
                 selectedPos = selected.a
             else:
                 selectedPos = selected.b
-        elif alt == "last_search":
+        elif alt == "last_search" or alt == "slurp_search":
             # Run the built in find_prev command from the window context
             return view.window().run_command("find_prev")
         elif alt == "clipboard":


### PR DESCRIPTION
The "slurp_search" option allows for another approach to the find usage. With "slurp_search" the selected text is placed into the find buffer (find_under / find_under_prev), so subsequent searches without a selection will use the buffer.  This allows for quick search and repeated edit operations.

The instructions I've added can be improved / written more fluid in your own words.
