### PR TITLE
Fix frequent console warning about bad mnemonic.

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,7 +1,7 @@
 [
     {
         "caption": "Find",
-        "mnemonic": "I",
+        "mnemonic": "i",
         "id": "find",
         "children":
         [


### PR DESCRIPTION
The published version kept spitting the following into the console:

warning: mnemonic I not found in menu caption Find
